### PR TITLE
Add simple Sphinx XML sitemap extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+examples/docs/_build/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md LICENSE
+exclude examples

--- a/README.md
+++ b/README.md
@@ -1,40 +1,60 @@
 # Simple Sphinx XML Sitemap Extension
 
-This is a simpler XML sitemap generator extension for Sphinx documentation. It does not support internationalization or multiple languages.
+This project provides a minimal Sphinx extension that generates an XML sitemap
+for your documentation.  The extension inspects the navigation structure of your
+project and writes a `sitemap.xml` file after the HTML build step completes.
 
-## Getting Started:
+The extension does not support internationalisation or multiple languages, but
+it is suitable for most single language documentation sites.
 
-TODO: UV install, PIP install, Poetry install instructions
+## Installation
 
-TODO: adding to pyproject.toml dev dependencies
+Install from PyPI using `pip`:
 
-TODO: Adding to sphinx `conf.py` file
+```bash
+pip install simple-sphinx-xml-sitemap
+```
+
+Alternatively add it to your `pyproject.toml` or `requirements.txt` file.
+
+## Usage
+
+Add the extension to the `extensions` list in your Sphinx `conf.py` file and
+set `html_baseurl` to the public URL where the documentation will be hosted.
 
 ```python
 extensions = [
-    # Other extensions
-    "simple-sphinx-xml-sitemap",  # This extension
+    # other extensions
+    'simple_sphinx_xml_sitemap',
 ]
+
+html_baseurl = 'https://example.com/docs/'
 ```
 
-TODO: Using with standard `sphinx-build` commands
+Build your documentation as normal:
 
 ```bash
-# Example of use here
-$ sphinx-build -b html docs docs/_build
+sphinx-build -b html docs docs/_build
 ```
 
-### Deployment Builds:
+After the build completes a `sitemap.xml` file will be present in the output
+folder.
 
-TODO: adding to deployment requirements.txt (link to example) for cloudflare pages / static site builder hosts.
+## Example
 
-### Why?
+An example project is provided under `examples/docs`.  Change to that directory
+and run `sphinx-build` to see the extension in action.
 
-The default behavior of search engines like Google is to crawl all pages of the sphinx documentation, including files that do not make sense to crawl.
+```bash
+cd examples/docs
+sphinx-build -b html . _build
+```
 
-Without an XML Sitemap, it's hard to tell Google which pages are most important and relevant, because there is duplicate content on `_sources/` and `_modules/` pages.
+The generated site will contain `sitemap.xml` alongside the HTML output.
 
-### How
+## Why
 
-This Sphinx Documentation XML Sitemap generator generates a sitemap based on your actual navigable content pages, and a couple other standard critical Sphinx documentation pages.
-
+Search engines often crawl every file of a Sphinx build, including sources and
+module documentation pages that may not be useful.  Providing an XML sitemap
+allows you to indicate which pages are important and helps search engines index
+your documentation correctly.

--- a/examples/docs/conf.py
+++ b/examples/docs/conf.py
@@ -1,0 +1,9 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+project = 'Example'
+extensions = ['simple_sphinx_xml_sitemap']
+html_baseurl = 'https://example.com/docs/'
+
+# minimal settings for demonstration

--- a/examples/docs/index.rst
+++ b/examples/docs/index.rst
@@ -1,0 +1,10 @@
+Example Documentation
+=====================
+
+Welcome to the example documentation.
+
+.. toctree::
+   :maxdepth: 1
+
+   page1
+   page2

--- a/examples/docs/page1.rst
+++ b/examples/docs/page1.rst
@@ -1,0 +1,4 @@
+Page One
+========
+
+This is the first example page.

--- a/examples/docs/page2.rst
+++ b/examples/docs/page2.rst
@@ -1,0 +1,4 @@
+Page Two
+========
+
+This is the second example page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "simple-sphinx-xml-sitemap"
+version = "0.1.0"
+description = "A simple Sphinx extension that generates an XML sitemap from navigation pages."
+authors = [{name = "Matthew Rideout"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+dependencies = ["Sphinx>=4"]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["simple_sphinx_xml_sitemap*"]

--- a/simple_sphinx_xml_sitemap/__init__.py
+++ b/simple_sphinx_xml_sitemap/__init__.py
@@ -1,0 +1,7 @@
+"""Simple Sphinx XML Sitemap Extension."""
+
+from .sitemap import setup
+
+__all__ = ["setup"]
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- implement `simple_sphinx_xml_sitemap` extension
- add packaging files and ignore build artifacts
- document usage and provide example docs site

## Testing
- `pip install -e .`
- `sphinx-build -b html . _build` in `examples/docs`

------
https://chatgpt.com/codex/tasks/task_e_6856bce2aa808321ae8ac6d0bbf5295e