### PR TITLE
Add hello_world example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ sphinx-build -b html docs docs/_build
 After the build completes a `sitemap.xml` file will be present in the output
 folder.
 
-## Example
+## Examples
 
-An example project is provided under `examples/docs`.  Change to that
-directory, create a virtual environment with `uv`, install the extension, and
-build the documentation:
+The `examples/` directory contains small projects showing different ways to use
+the extension.
+
+### `docs`
+
+This directory contains only a Sphinx project.  To build it run:
 
 ```bash
 cd examples/docs
@@ -56,7 +59,21 @@ uv pip install -e ../..
 sphinx-build -b html . _build
 ```
 
-The generated site will contain `sitemap.xml` alongside the HTML output.
+### `hello_world`
+
+This example is a tiny Python package with a documentation folder and its own
+`pyproject.toml`.  Build the docs and install the package in editable mode:
+
+```bash
+cd examples/hello_world
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+uv pip install -e ../..
+sphinx-build -b html docs docs/_build
+```
+
+Both examples will produce a `sitemap.xml` alongside the HTML output.
 
 ## Why
 

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,0 +1,4 @@
+# Hello World Example
+
+This example demonstrates using the `simple-sphinx-xml-sitemap` extension in a
+small Python project.

--- a/examples/hello_world/docs/conf.py
+++ b/examples/hello_world/docs/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+# Include the project package and extension
+sys.path.insert(0, os.path.abspath('..'))  # hello_world package
+sys.path.insert(0, os.path.abspath('../../../'))  # extension root
+
+project = 'Hello World Example'
+extensions = ['simple_sphinx_xml_sitemap']
+html_baseurl = 'https://example.com/hello/'
+
+# minimal settings for demonstration

--- a/examples/hello_world/docs/index.rst
+++ b/examples/hello_world/docs/index.rst
@@ -1,0 +1,9 @@
+Hello World Example
+===================
+
+Welcome to the Hello World example project.
+
+.. toctree::
+   :maxdepth: 1
+
+   usage

--- a/examples/hello_world/docs/usage.rst
+++ b/examples/hello_world/docs/usage.rst
@@ -1,0 +1,6 @@
+Usage
+=====
+
+Run the example package to print the message::
+
+   python -m hello_world

--- a/examples/hello_world/hello_world/__init__.py
+++ b/examples/hello_world/hello_world/__init__.py
@@ -1,0 +1,13 @@
+"""Simple hello world package."""
+
+def say_hello() -> str:
+    """Return a hello world message."""
+    return "Hello, world!"
+
+
+def main() -> None:
+    """Print the hello message."""
+    print(say_hello())
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello_world/pyproject.toml
+++ b/examples/hello_world/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hello-world-example"
+version = "0.1.0"
+description = "A simple hello world example project."
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.setuptools.packages.find]
+where = ["hello_world"]


### PR DESCRIPTION
## Summary
- add a `hello_world` example with docs and pyproject
- update README with instructions for both examples

## Testing
- `pip install -e .`
- `sphinx-build -b html examples/docs examples/docs/_build`
- `sphinx-build -b html examples/hello_world/docs examples/hello_world/docs/_build`


------
https://chatgpt.com/codex/tasks/task_e_6856c2c9dccc83218d7d14509fcc1002