### PR TITLE
Improve sitemap filtering and ignore local venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.py[cod]
 examples/docs/_build/
 *.egg-info/
+.venv/
+.vscode/


### PR DESCRIPTION
## Summary
- filter docnames that contain hidden path components
- skip hidden output paths when building the XML sitemap
- ignore `.venv` and `.vscode` directories

## Testing
- `python -m pip install -e .`
- `python -m sphinx -b html examples/docs examples/docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_6856c56122cc83219fabb6b9886778ef