### PR TITLE
Fix docs build in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ uv pip install -e ../..
 sphinx-build -b html . _build
 ```
 
+The example ``conf.py`` excludes the ``.venv`` directory created above so that
+Sphinx does not try to parse files inside the virtual environment.
+
 ### `hello_world`
 
 This example is a tiny Python package with a documentation folder and its own

--- a/examples/docs/conf.py
+++ b/examples/docs/conf.py
@@ -6,4 +6,9 @@ project = 'Example'
 extensions = ['simple_sphinx_xml_sitemap']
 html_baseurl = 'https://example.com/docs/'
 
+# Exclude the virtual environment so Sphinx does not try to parse files inside
+# ``.venv`` when building the docs. Without this exclusion Sphinx may pick up
+# ``.rst`` files from dependencies which can lead to confusing errors.
+exclude_patterns = ['_build', '.venv']
+
 # minimal settings for demonstration


### PR DESCRIPTION
## Summary
- exclude `.venv` from the example Sphinx configuration
- note the exclusion in the README docs example

## Testing
- `python3 -m pip install -e .`
- `python3 -m sphinx -b html . _build` in `examples/docs`

------
https://chatgpt.com/codex/tasks/task_e_6856c755d85083219821ea74d0f84d69