### PR TITLE
Add HelloWorld class example with docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.py[cod]
 examples/docs/_build/
+examples/hello_world/docs/_build/
 *.egg-info/
 .venv/
 .vscode/

--- a/examples/hello_world/docs/api.rst
+++ b/examples/hello_world/docs/api.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. automodule:: hello_world
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/hello_world/docs/conf.py
+++ b/examples/hello_world/docs/conf.py
@@ -6,7 +6,10 @@ sys.path.insert(0, os.path.abspath('..'))  # hello_world package
 sys.path.insert(0, os.path.abspath('../../../'))  # extension root
 
 project = 'Hello World Example'
-extensions = ['simple_sphinx_xml_sitemap']
+extensions = [
+    'simple_sphinx_xml_sitemap',
+    'sphinx.ext.autodoc',
+]
 html_baseurl = 'https://example.com/hello/'
 
 # minimal settings for demonstration

--- a/examples/hello_world/docs/index.rst
+++ b/examples/hello_world/docs/index.rst
@@ -7,3 +7,5 @@ Welcome to the Hello World example project.
    :maxdepth: 1
 
    usage
+   api
+   pyproject

--- a/examples/hello_world/docs/pyproject.rst
+++ b/examples/hello_world/docs/pyproject.rst
@@ -1,0 +1,8 @@
+Pyproject Configuration
+=======================
+
+The example project uses `uv` for managing dependencies. Below is the
+`pyproject.toml` file used by the project.
+
+.. literalinclude:: ../pyproject.toml
+   :language: toml

--- a/examples/hello_world/docs/usage.rst
+++ b/examples/hello_world/docs/usage.rst
@@ -4,3 +4,10 @@ Usage
 Run the example package to print the message::
 
    python -m hello_world
+
+You can also use the :class:`hello_world.HelloWorld` class in your own code::
+
+   from hello_world import HelloWorld
+
+   HelloWorld.say_hello()
+

--- a/examples/hello_world/hello_world/__init__.py
+++ b/examples/hello_world/hello_world/__init__.py
@@ -1,13 +1,19 @@
-"""Simple hello world package."""
 
-def say_hello() -> str:
-    """Return a hello world message."""
-    return "Hello, world!"
+"""Simple hello world package providing a small library."""
+
+
+class HelloWorld:
+    """Utility class to print a hello world message."""
+
+    @staticmethod
+    def say_hello() -> None:
+        """Print ``"Hello, world!"`` to standard output."""
+        print("Hello, world!")
 
 
 def main() -> None:
-    """Print the hello message."""
-    print(say_hello())
+    """Demonstrate the :class:`HelloWorld` API by printing the message."""
+    HelloWorld.say_hello()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- turn hello_world example into a small library exposing `HelloWorld.say_hello`
- document API using autodoc and include pyproject configuration
- generate sitemap entries for the new pages

## Testing
- `pip install -e .`
- `sphinx-build -b html examples/hello_world/docs examples/hello_world/docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_6856c9d5ac28832189ec7455949d2111