### PR TITLE
Use uv workspace in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ folder.
 ## Examples
 
 The `examples/` directory contains small projects showing different ways to use
-the extension.
+the extension. The project is configured as a uv workspace so these examples can
+declare `simple-sphinx-xml-sitemap` as a dependency in their own
+`pyproject.toml` files.
 
 ### `docs`
 
@@ -55,7 +57,7 @@ This directory contains only a Sphinx project.  To build it run:
 cd examples/docs
 uv venv
 source .venv/bin/activate
-uv pip install -e ../..
+uv pip install -e .
 sphinx-build -b html . _build
 ```
 
@@ -72,7 +74,6 @@ cd examples/hello_world
 uv venv
 source .venv/bin/activate
 uv pip install -e .
-uv pip install -e ../..
 sphinx-build -b html docs docs/_build
 ```
 

--- a/examples/docs/conf.py
+++ b/examples/docs/conf.py
@@ -1,6 +1,3 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../..'))
 
 project = 'Example'
 extensions = ['simple_sphinx_xml_sitemap']

--- a/examples/docs/pyproject.toml
+++ b/examples/docs/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "docs-example"
+version = "0.1.0"
+dependencies = [
+    "simple-sphinx-xml-sitemap",
+]
+
+[tool.uv.sources]
+simple-sphinx-xml-sitemap = { workspace = true }

--- a/examples/hello_world/pyproject.toml
+++ b/examples/hello_world/pyproject.toml
@@ -8,6 +8,12 @@ version = "0.1.0"
 description = "A simple hello world example project."
 readme = "README.md"
 requires-python = ">=3.8"
+dependencies = [
+    "simple-sphinx-xml-sitemap",
+]
+
+[tool.uv.sources]
+simple-sphinx-xml-sitemap = { workspace = true }
 
 [tool.setuptools.packages.find]
 where = ["hello_world"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ Homepage = "https://example.com"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["simple_sphinx_xml_sitemap*"]
+
+[tool.uv.workspace]
+members = ["examples/*"]


### PR DESCRIPTION
## Summary
- create pyproject for `examples/docs`
- link examples to workspace to use local extension
- declare uv workspace members in root `pyproject.toml`
- adjust README instructions and remove sys.path tweak in docs example

## Testing
- `python -m py_compile simple_sphinx_xml_sitemap/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6856cd0d954483218574790111178568