### PR TITLE
Fix docs example build

### DIFF
--- a/examples/docs/pyproject.toml
+++ b/examples/docs/pyproject.toml
@@ -11,3 +11,7 @@ dependencies = [
 
 [tool.uv.sources]
 simple-sphinx-xml-sitemap = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = []
+bypass-selection = true


### PR DESCRIPTION
## Summary
- add packages override for hatch
- bypass file-selection heuristics in the docs example

## Testing
- `hatchling build -t wheel`

------
https://chatgpt.com/codex/tasks/task_e_6856d0f726848321985e889b9763fbc4