### PR TITLE
Improve hello world docs

### DIFF
--- a/examples/hello_world/docs/api.rst
+++ b/examples/hello_world/docs/api.rst
@@ -1,7 +1,15 @@
 API Reference
 =============
 
-.. automodule:: hello_world
+Modules
+-------
+
+.. automodule:: hello_world.hello
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: hello_world.helpers
    :members:
    :undoc-members:
    :show-inheritance:

--- a/examples/hello_world/docs/conf.py
+++ b/examples/hello_world/docs/conf.py
@@ -6,10 +6,19 @@ sys.path.insert(0, os.path.abspath('..'))  # hello_world package
 sys.path.insert(0, os.path.abspath('../../../'))  # extension root
 
 project = 'Hello World Example'
+
 extensions = [
     'simple_sphinx_xml_sitemap',
-    'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc',  # Core Sphinx library for auto html doc generation
+    'sphinx.ext.napoleon',  # Support for NumPy and Google style docstrings
+    'sphinx.ext.viewcode',  # Add links to highlighted source code
+    'sphinx.ext.intersphinx',  # Link to other project's documentation (see mapping below)
+    'sphinx.ext.doctest',  # Test code examples in docstrings
+    'sphinx.ext.todo',  # Support for TODO items
+    'sphinx.ext.coverage',  # Check documentation coverage
+    'sphinx.ext.ifconfig',  # Conditional content based on configuration
 ]
+
 html_baseurl = 'https://example.com/hello/'
 
 # minimal settings for demonstration

--- a/examples/hello_world/docs/helpers.rst
+++ b/examples/hello_world/docs/helpers.rst
@@ -1,0 +1,8 @@
+Helper Utilities
+================
+
+.. automodule:: hello_world.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/examples/hello_world/docs/index.rst
+++ b/examples/hello_world/docs/index.rst
@@ -8,4 +8,5 @@ Welcome to the Hello World example project.
 
    usage
    api
+   helpers
    pyproject

--- a/examples/hello_world/docs/usage.rst
+++ b/examples/hello_world/docs/usage.rst
@@ -9,5 +9,13 @@ You can also use the :class:`hello_world.HelloWorld` class in your own code::
 
    from hello_world import HelloWorld
 
-   HelloWorld.say_hello()
+   hello = HelloWorld()
+   hello.say_hello()
 
+   hello.say_hello("Alice")
+
+The :mod:`hello_world.helpers` module provides additional functions::
+
+   from hello_world.helpers import greet
+
+   print(greet("Alice"))

--- a/examples/hello_world/hello_world/__init__.py
+++ b/examples/hello_world/hello_world/__init__.py
@@ -1,19 +1,9 @@
+"""Simple hello world package providing a small library.
 
-"""Simple hello world package providing a small library."""
+The package exposes :class:`.HelloWorld` and a :func:`.main` helper used
+throughout the documentation.
+"""
 
+from .hello import HelloWorld, main
 
-class HelloWorld:
-    """Utility class to print a hello world message."""
-
-    @staticmethod
-    def say_hello() -> None:
-        """Print ``"Hello, world!"`` to standard output."""
-        print("Hello, world!")
-
-
-def main() -> None:
-    """Demonstrate the :class:`HelloWorld` API by printing the message."""
-    HelloWorld.say_hello()
-
-if __name__ == "__main__":
-    main()
+__all__ = ["HelloWorld", "main"]

--- a/examples/hello_world/hello_world/hello.py
+++ b/examples/hello_world/hello_world/hello.py
@@ -1,0 +1,52 @@
+"""Utilities for printing greeting messages.
+
+The module exposes :class:`HelloWorld`, which shows how to write
+Sphinx-style docstrings. It also provides a ``main`` entry point that
+invokes the class.
+"""
+
+class HelloWorld:
+    """Print configurable greeting messages.
+
+    :param default_name: Name used when no ``name`` is provided.
+    :type default_name: str
+    """
+
+    def __init__(self, default_name: str = "world") -> None:
+        self.default_name = default_name
+
+    def build_message(self, name: str | None = None) -> str:
+        """Create a greeting message.
+
+        :param name: Person to greet. Defaults to ``default_name``.
+        :type name: str | None
+        :return: The formatted greeting.
+        :rtype: str
+        """
+
+        target = name or self.default_name
+        return f"Hello, {target}!"
+
+    def say_hello(self, name: str | None = None) -> None:
+        """Print a greeting message.
+
+        :param name: Optional name to greet.
+        :type name: str | None
+        :returns: ``None``
+        :rtype: None
+        """
+
+        print(self.build_message(name))
+
+
+def main() -> None:
+    """Run a short demonstration of :class:`HelloWorld`.
+
+    :returns: ``None``
+    :rtype: None
+    """
+
+    HelloWorld().say_hello()
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello_world/hello_world/helpers.py
+++ b/examples/hello_world/hello_world/helpers.py
@@ -1,0 +1,48 @@
+"""Additional helper utilities for greeting people.
+
+The module contains a small API consisting of a function and a dataclass
+that showcase Sphinx-style docstrings.
+"""
+
+from dataclasses import dataclass
+
+
+def greet(name: str) -> str:
+    """Return a personalized greeting message.
+
+    :param name: Name of the person to greet.
+    :type name: str
+    :return: A greeting containing ``name``.
+    :rtype: str
+    """
+
+    return f"Hello, {name}!"
+
+
+@dataclass
+class Greeter:
+    """Class for creating greeter objects.
+
+    :param default_name: Fallback when ``name`` is not provided.
+    :type default_name: str
+    :param prefix: Text used before the name in greetings.
+    :type prefix: str
+    """
+
+    default_name: str = "world"
+    prefix: str = "Hello"
+
+    def greet(self, name: str | None = None, times: int = 1) -> str:
+        """Return a greeting.
+
+        :param name: Optional name to greet. If omitted, ``default_name`` is used.
+        :type name: str | None
+        :param times: Number of times to repeat the greeting.
+        :type times: int
+        :return: The greeting repeated ``times`` times.
+        :rtype: str
+        """
+
+        target = name or self.default_name
+        message = f"{self.prefix}, {target}!"
+        return " ".join([message] * times)


### PR DESCRIPTION
## Summary
- turn HelloWorld into a dedicated module and add helper utilities
- show helper module docs
- enable viewcode and other sphinx extensions
- update example usage in docs
- improve docstrings for hello modules

## Testing
- `sphinx-build -b html docs docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_6856d4c4383c83219521db31824cfb8f