### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,12 @@ jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/simple-sphinx-xml-sitemap/
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,9 +30,6 @@ jobs:
         run: |
           pip install build
           python -m build
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/README.md
+++ b/README.md
@@ -99,3 +99,14 @@ Search engines often crawl every file of a Sphinx build, including sources and
 module documentation pages that may not be useful.  Providing an XML sitemap
 allows you to indicate which pages are important and helps search engines index
 your documentation correctly.
+
+## Publishing to PyPI
+
+This project uses [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/)
+with the [`pypi-publish` GitHub Action](https://github.com/marketplace/actions/pypi-publish).
+To enable it:
+
+1. On PyPI, add this repository as a trusted publisher. Select the workflow file
+   `.github/workflows/publish.yml` and, if desired, specify the `pypi` environment.
+2. Push your changes to the `main` branch. The `CI` workflow will build the
+   package and the `Publish` workflow will upload the distribution to PyPI.


### PR DESCRIPTION
## Summary
- use GitHub's `pypi-publish` action with OIDC
- document how to configure trusted publishing

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e7efa9b083218aad31bb2e110b51